### PR TITLE
Add 'FizzBuzz' kata

### DIFF
--- a/lib/exercism/elixir/fizz_buzz/README.md
+++ b/lib/exercism/elixir/fizz_buzz/README.md
@@ -1,0 +1,10 @@
+# FizzBuzz
+
+Write a program that prints the integers from 1 to 100 (inclusive).
+
+But:
+  for multiples of three, print Fizz (instead of the number)
+  for multiples of five, print Buzz (instead of the number)
+  for multiples of both three and five, print FizzBuzz (instead of the number)
+
+The FizzBuzz problem was presented as the lowest level of comprehension required to illustrate adequacy.

--- a/lib/exercism/elixir/fizz_buzz/fizz_buzz.exs
+++ b/lib/exercism/elixir/fizz_buzz/fizz_buzz.exs
@@ -1,0 +1,18 @@
+defmodule FizzBuzz do
+  @doc """
+  Returns whether 'year' is a leap year.
+
+  A leap year occurs:
+
+  on every year that is evenly divisible by 4
+    except every year that is evenly divisible by 100
+      unless the year is also evenly divisible by 400
+  """
+  # @spec call() :: []
+  def call(range), do: range |> Enum.map(&fizz_buzz/1)
+
+  defp fizz_buzz(x) when rem(x, 3) === 0 and rem(x, 5) === 0, do: "FizzBuzz"
+  defp fizz_buzz(x) when rem(x, 3) === 0, do: "Fizz"
+  defp fizz_buzz(x) when rem(x, 5) === 0, do: "Buzz"
+  defp fizz_buzz(x), do: x
+end

--- a/lib/exercism/elixir/fizz_buzz/fizz_buzz_test.exs
+++ b/lib/exercism/elixir/fizz_buzz/fizz_buzz_test.exs
@@ -1,0 +1,28 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("fizz_buzz.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule FizzBuzzTest do
+  use ExUnit.Case
+
+  test "from 1 to 2" do
+    assert FizzBuzz.call(1..2) == [1, 2]
+  end
+
+  test "from 1 to 5" do
+    assert FizzBuzz.call(1..5) == [1, 2, "Fizz", 4, "Buzz"]
+  end
+
+  test "from 9 to 15" do
+    assert FizzBuzz.call(9..15) ==
+      ["Fizz", "Buzz", 11, "Fizz", 13, 14, "FizzBuzz"]
+  end
+
+  test "only 15, 30, 45" do
+    assert FizzBuzz.call([15, 30, 45]) ==
+      ["FizzBuzz", "FizzBuzz", "FizzBuzz"]
+  end
+end


### PR DESCRIPTION
# FizzBuzz

Write a program that prints the integers from 1 to 100 (inclusive).

But:
  for multiples of three, print Fizz (instead of the number)
  for multiples of five, print Buzz (instead of the number)
  for multiples of both three and five, print FizzBuzz (instead of the number)

The FizzBuzz problem was presented as the lowest level of comprehension required to illustrate adequacy.